### PR TITLE
Possible fix for the History page  - buttons not wrapping correctly

### DIFF
--- a/src/ServiceQuality/Views/Service/History.cshtml
+++ b/src/ServiceQuality/Views/Service/History.cshtml
@@ -19,7 +19,7 @@
                 @Html.DisplayNameFor(model => model.Success)
             </th>
             <th>
-                Service URL
+                @Html.DisplayNameFor(model => model.Url)
             </th>
             <th></th>
         </tr>


### PR DESCRIPTION
added this back into the URL line:
@Html.DisplayNameFor(model => model.Url)
